### PR TITLE
Logger: fix level setting

### DIFF
--- a/alertmanager_gchat_integration/app.py
+++ b/alertmanager_gchat_integration/app.py
@@ -16,7 +16,7 @@ CONFIG = toml.load(os.environ.get('CONFIG_FILE_LOCATION', 'config.toml'))
 
 # Logger Setup
 LOGGER = create_logger(app)
-LOGGER.setLevel(os.environ.get('LOGLEVEL', logging.INFO).upper())
+LOGGER.setLevel(os.environ.get('LOGLEVEL', logging.INFO))
 
 # Metrics set-up
 metrics = PrometheusMetrics(app)


### PR DESCRIPTION
This makes the log level configuration more strict. I'm not even sure `create_logger` can take a string as argument, but I haven't checked.